### PR TITLE
Add preview link to PR description in deployment workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,3 +25,31 @@ jobs:
         with:
           config: fly.preview.toml
           memory: 256
+
+      - name: Update PR description with preview link
+        if: github.event.action != 'closed'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          preview_url="${{ steps.deploy.outputs.url }}"
+          if [ -z "$preview_url" ]; then
+            echo "No preview URL available, skipping"
+            exit 0
+          fi
+
+          body=$(gh pr view "${{ github.event.number }}" --json body --jq '.body // ""')
+
+          marker_start="<!-- preview-link -->"
+          marker_end="<!-- /preview-link -->"
+          preview_block=$(printf '%s\n\n---\n\n**Preview:** %s\n%s' "$marker_start" "$preview_url" "$marker_end")
+
+          if echo "$body" | grep -q "$marker_start"; then
+            new_body=$(echo "$body" | awk -v block="$preview_block" \
+              '/<!-- preview-link -->/{skip=1; print block; next}
+               /<!-- \/preview-link -->/{skip=0; next}
+               !skip{print}')
+          else
+            new_body=$(printf '%s\n\n%s' "$body" "$preview_block")
+          fi
+
+          gh pr edit "${{ github.event.number }}" --body "$new_body"


### PR DESCRIPTION
## Summary
This change enhances the preview deployment workflow by automatically updating the pull request description with a link to the deployed preview environment.

## Key Changes
- Added a new workflow step that runs after successful deployment to update the PR description
- The step extracts the preview URL from the deployment output and adds it to the PR body
- Uses HTML comment markers (`<!-- preview-link -->`) to identify and manage the preview link section
- If a preview link section already exists, it updates the URL in place; otherwise, it appends a new section
- The update is skipped if the PR is closed or if no preview URL is available

## Implementation Details
- Uses GitHub CLI (`gh`) to fetch the current PR body and update it
- Implements idempotent updates by checking for existing preview link markers
- The preview block is formatted with a visual separator and clearly labeled as "Preview"
- Only runs on non-closed PR events to avoid unnecessary updates

https://claude.ai/code/session_01WgSTjAJtikYu3mvhCY9Wcu